### PR TITLE
New Jenkins no sh plugins

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -3,7 +3,7 @@ ENV JAVA_OPTS=-Djenkins.install.runSetupWizard=false
 
 # Install Plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN  jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
 
 # Add JCasC
 ENV CASC_JENKINS_CONFIG=/var/jenkins_home/casc_configs


### PR DESCRIPTION
Latest Jenkins has no install-plugins.sh, new cli replaces it.

Thanks for this project.

